### PR TITLE
explicitly declare volumeName and match storage class name of pv

### DIFF
--- a/templates/pv.yaml
+++ b/templates/pv.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolume
 metadata:
   name: nginx-pv
 spec:
+  storageClassName: ""
   capacity:
     storage: 1Gi
   accessModes:

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -3,8 +3,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: nginx-pvc
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
+  volumeName: nginx-pv


### PR DESCRIPTION
You have to explicitly declare the volumeName and [use empty storageClassName](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#:~:text=PVCs%20don%27t%20necessarily%20have%20to%20request%20a%20class.%20A%20PVC%20with%20its%20storageClassName%20set%20equal%20to%20%22%22%20is%20always%20interpreted%20to%20be%20requesting%20a%20PV%20with%20no%20class%2C%20so%20it%20can%20only%20be%20bound%20to%20PVs%20with%20no%20class%20(no%20annotation%20or%20one%20set%20equal%20to%20%22%22).) if you want to use your own PV.
Otherwise, it will use default storage provisioner if you have any like "standard" which is the default storage provisioner in Minikube (you can check by using `kubectl get storageclass`).

If you use default storageClass in Minikube, it will automatically create PV and bound your PVC into it that means you didn't use your PV that defined in the Helm template.
<img width="611" alt="Screenshot 2567-12-23 at 13 23 57" src="https://github.com/user-attachments/assets/67ef1e82-5cdf-4d22-8e66-c9cfefac865e" />

If you set up correctly, you should be able to get the file in Minikube instance under "/mnt/data" that you configured in PV hostPath section.
![Screenshot 2567-12-23 at 14 13 05](https://github.com/user-attachments/assets/34197fca-1b53-46a3-8613-0036925f2770)

